### PR TITLE
fix `make_string`

### DIFF
--- a/src/common/common_definitions.jl
+++ b/src/common/common_definitions.jl
@@ -17,7 +17,7 @@ abstract type CmdStanModels end
 make_string = "make"
 
 if Sys.iswindows()
-    make_command =  "mingw32-" * make
+    make_command =  "mingw32-" * make_string
 end
 
 """


### PR DESCRIPTION
Precompilation for StanSample failed because the variable `make` was not defined.