### PR TITLE
Removal of StanDump necessitates removal of update_R_files

### DIFF
--- a/src/StanBase.jl
+++ b/src/StanBase.jl
@@ -16,7 +16,7 @@ include("common/cmdstan_home.jl")
 include("common/common_definitions.jl")
 include("common/handle_keywords.jl")
 include("common/update_model_file.jl")
-include("common/update_R_files.jl")
+# include("common/update_R_files.jl")
 include("common/update_json_files.jl")
 include("common/par.jl")
 


### PR DESCRIPTION
This is a natural consequence of removing `StanDump` and support
for R files. Incidentally, `StanSample.stan_sample` is broken for
for `use_json=false`.